### PR TITLE
Simplified Dockerfile for Alpine Linux

### DIFF
--- a/dockerfiles/alpine_ocaml/.jupyter/custom/custom.css
+++ b/dockerfiles/alpine_ocaml/.jupyter/custom/custom.css
@@ -1,0 +1,3 @@
+.CodeMirror pre, .output pre {
+  font-family: "Ricty Diminished Discord", "Ricty Diminished", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Lucida Console", Monaco, "Courier New", Consolas, monospace;
+}

--- a/dockerfiles/alpine_ocaml/.jupyter/custom/custom.js
+++ b/dockerfiles/alpine_ocaml/.jupyter/custom/custom.js
@@ -1,0 +1,2 @@
+var img = $('.container img')[0];
+img.src = 'https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/PNG/colour-logo.png';

--- a/dockerfiles/alpine_ocaml/.jupyter/nbconfig/notebook.json
+++ b/dockerfiles/alpine_ocaml/.jupyter/nbconfig/notebook.json
@@ -1,0 +1,13 @@
+{
+  "Cell": {
+    "load_extensions": {
+      "contrib_nbextensions_help_item/main": true,
+      "nbextensions_configurator/config_menu/main": true
+    },
+    "cm_config": {
+      "indentUnit": 2,
+      "lineNumbers": true,
+      "autoCloseBrackets": true
+    }
+  }
+}

--- a/dockerfiles/alpine_ocaml/.ocamlinit
+++ b/dockerfiles/alpine_ocaml/.ocamlinit
@@ -1,0 +1,7 @@
+let () =
+  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ()
+;;
+
+#use "topfind" ;;
+Topfind.log := ignore ;; (* prevent noisy logs *)

--- a/dockerfiles/alpine_ocaml/Dockerfile
+++ b/dockerfiles/alpine_ocaml/Dockerfile
@@ -1,0 +1,37 @@
+ARG OCAML_VERSION=4.07.0
+FROM akabe/ocaml:alpine_ocaml$OCAML_VERSION
+
+ENV PATH $PATH:/home/opam/.local/bin
+
+RUN sudo apk add --upgrade --no-cache zlib gmp zeromq python && \
+    sudo apk add --upgrade --no-cache \
+                 --virtual=.build-dependencies \
+                 curl m4 perl zlib-dev gmp-dev zeromq-dev libffi-dev python-dev py2-pip && \
+    \
+    sudo pip2 install --upgrade pip && \
+    pip2 install --user --no-cache-dir 'setuptools>=18.5' 'six>=1.9.0' jupyter && \
+    mkdir -p /home/opam/.jupyter && \
+    \
+    opam update && \
+    opam install -y 'merlin>=3.0.0' ocaml-migrate-parsetree jupyter && \
+    jupyter kernelspec install --user --name ocaml-jupyter "$(opam config var share)/jupyter" && \
+    \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/man \
+           $HOME/.opam/$OCAML_VERSION/build && \
+    \
+    sudo apk del .build-dependencies && sudo rm -rf /var/cache/apk/*
+
+VOLUME /notebooks
+VOLUME /home/opam/.jupyter
+WORKDIR /notebooks
+
+COPY entrypoint.sh /
+COPY .ocamlinit    /home/opam/.ocamlinit
+COPY .jupyter      /home/opam/.jupyter
+
+EXPOSE 8888
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "jupyter-notebook", "--no-browser", "--ip=*", "--NotebookApp.token="]

--- a/dockerfiles/alpine_ocaml/entrypoint.sh
+++ b/dockerfiles/alpine_ocaml/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+sudo chown -hR opam:opam /home/opam/.jupyter
+sudo chown -hR opam:opam /notebooks
+opam config exec -- "$@"


### PR DESCRIPTION
I am creating this pull request because I have no other way to suggest a few changes in the Dockerfile... Sorry if this is too intrusive.

Feel free to take any ideas from it or just discard all, again, sorry if I am too intrusive.

 * Instead of creating a different Dockerfile for every distro/OCaml
 version, use the ARG parameter in Docker to simplify the build
 * Now to build a specific OCaml version, just run `docker build
 --build-arg OCAML_VERSION=4.07.0 -t akabe/ocaml-jupyter`
 * This can be simplified for distro as well
 * Remove apk cache directory, it saves a few bytes
 * Use Python 2 instead of 3, it saves 9MB of size
 * Python 2 version works fine with OCaml syntax highlighting!
 * Python 2 version displays the OCaml logo, for some reason the Python
 3 version doesn't